### PR TITLE
docs: translate and refine contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,36 +1,121 @@
 # Contributing Guide — Mindeck
 
-Стратегия: **GitHub Flow** + **Conventional Commits**
+Strategy: **GitHub Flow** + **Conventional Commits**
 
 ---
 
-## Ветки
+## Issues
 
-### Шаблон
+An issue is created **before** the branch — the issue number is required in the branch name (see below).
+
+### Title
+
+Same format as commits/PRs:
+
+```
+<type>(<scope>): <description>
+```
+
+- `scope` may be omitted if the issue is not tied to a single module
+- `type` — from the type table in the "Branches" section
+
+Examples from the repository:
+```
+fix(data): validate photo-by-link URL to prevent SSRF in FileDownloaderImpl
+fix(core-mvi): add CoroutineExceptionHandler to BaseViewModel.viewModelScope
+feat: add media input options for cards
+```
+
+### Labels
+
+Priority is set with a label:
+
+| Label | When |
+|---|---|
+| `high` | critical / blocks the release |
+| `medium` | important, but not blocking |
+| `low` | can be deferred |
+
+### Issue body
+
+**Bug / fix** — structure `Problem` → `Impact` → `Reproduction` → `Where`:
+
+```markdown
+## Problem
+
+What is broken and why: the specific file/line, the call chain if it matters for
+understanding the bug.
+
+## Impact
+
+What happens because of the bug (if not obvious from Problem).
+
+## Reproduction
+
+1. Step
+2. Step
+
+**Expected:** what should happen.
+**Actual:** what actually happens.
+**Environment:** device / OS / version (if relevant).
+
+## Where
+
+- `path/to/File.kt`
+- `path/to/OtherFile.kt`
+```
+
+`Impact` and `Reproduction` are optional: omit `Impact` when it is obvious from `Problem`;
+add `Reproduction` for bugs reproducible by hand (UI/runtime), and omit it for purely static
+findings (naming, dead code).
+
+Do not add `## Fix` — the proposed solution belongs in the PR/discussion, not in the issue. Do
+not add `Source:`/references to where the problem came from (audit, chat, etc.) — an issue
+describes the problem on its own.
+
+If an issue describes several independent problems, number the blocks with a heading
+`## N. Severity — title` (example — `#98`: `## 1. Critical — ...`, `## 2. High — ...`),
+each block with its own `Problem`/`Impact`.
+
+**Feature** — a short description + a list of scope items, no required subheadings:
+
+```markdown
+Add multiple ways to attach media to a card:
+
+- Add image/audio by URL
+- Pick image/audio from device storage
+- Take a photo with camera
+```
+
+---
+
+## Branches
+
+### Template
 
 ```
 <type>/<issue-id>/<short-description>
 ```
 
-- `type` — тип изменения (см. таблицу ниже)
-- `issue-id` — номер GitHub Issue, **обязателен** (создать issue перед веткой)
-- `short-description` — 2-4 слова через дефис, английский, lowercase
+- `type` — the type of change (see the table below)
+- `issue-id` — the GitHub Issue number, **required** (create the issue before the branch)
+- `short-description` — 2-4 words separated by hyphens, English, lowercase
 
-### Типы
+### Types
 
-| Тип | Когда использовать |
+| Type | When to use |
 |---|---|
-| `feat` | Новая функциональность |
-| `fix` | Исправление бага |
-| `refactor` | Рефакторинг без изменения поведения |
-| `chore` | Зависимости, конфиги, сборка |
-| `docs` | Документация |
-| `test` | Тесты |
-| `ci` | CI/CD пайплайн |
-| `perf` | Оптимизация производительности |
-| `style` | Форматирование, lint (без логики) |
+| `feat` | New functionality |
+| `fix` | Bug fix |
+| `refactor` | Refactoring with no behavior change |
+| `chore` | Dependencies, configs, build |
+| `docs` | Documentation |
+| `test` | Tests |
+| `ci` | CI/CD pipeline |
+| `perf` | Performance optimization |
+| `style` | Formatting, lint (no logic) |
 
-### Примеры
+### Examples
 
 ```
 feat/12/card-study-screen
@@ -43,18 +128,21 @@ ci/add-lint-workflow
 
 ---
 
-## Коммиты
+## Commits
 
-Формат по [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/):
+Format per [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/):
 
 ```
 <type>(<scope>): <description>
 ```
 
-- `scope` — модуль или фича: `domain`, `data`, `home`, `card`, `core-ui`, `core-mvi`, `navigation`, `app`
-- `description` — что сделано, lowercase, без точки в конце
+- `scope` — module or feature: `domain`, `data`, `home`, `card`, `core-ui`, `core-mvi`, `navigation`, `app`
+- `description` — what was done, lowercase, no trailing period (≤50 characters)
+- commit body — **optional**: only for non-trivial changes (a blank line after the subject,
+  wrapped at 72 characters, "what and why", not "how"). For small/self-explanatory changes —
+  just the subject, no body
 
-### Примеры
+### Examples
 
 ```
 feat(card): add card study screen
@@ -77,56 +165,64 @@ BREAKING CHANGE: CardRepository removed, use CardQueryRepository and CardCommand
 
 ## Pull Requests
 
-### Заголовок PR = первый коммит или суть ветки
+### PR title = the first commit or the gist of the branch
 
 ```
 <type>(<scope>): <description>
 ```
 
-Примеры:
+Examples:
 ```
 feat(card): add deck selection to creation card screen
 fix(data): fix room migration from version 3 to 4
 refactor(domain): extract use case types into subpackages
 ```
 
-### Описание PR (шаблон)
+Do **not** add the issue number to the title. The title must stay a valid Conventional
+Commit: on squash-merge GitHub uses it as the commit message, and PR-title linters and
+`semantic-release` parse it — a prefix like `#42 ` breaks them. Link the issue via
+`Closes #<id>` in the PR body (below). The number is also already in the branch name.
+
+### PR description (template)
 
 ```markdown
-## Что сделано
+## What
 - ...
 
-## Почему
+## Why
 - ...
 
-## Как проверить
+## How to test
 - ...
 
-closes #<issue-id>
+Closes #<issue-id>
 ```
 
-> `closes #42` — GitHub автоматически закроет Issue при merge в `develop`.
+> `Closes #42` — GitHub closes the issue automatically on merge into `develop`. This is how
+> (rather than with a number in the title) we link a PR to an issue.
 
 ---
 
-## Правила GitHub Flow
+## GitHub Flow rules
 
-1. `develop` — основная ветка, всегда рабочая
-2. Любое изменение — через ветку + PR, напрямую не коммитить
-3. Ветка живёт максимум 1-3 дня — дольше = риск конфликтов
-4. PR требует ревью перед merge (даже соло — self-review)
-5. После merge ветка удаляется
-6. CI должен быть зелёным перед merge
+1. `develop` — the main branch, always working
+2. Any change — through a branch + PR, never commit directly
+3. A branch lives 1-3 days max — longer = risk of conflicts
+4. A PR requires review before merge (even solo — self-review)
+5. After merge the branch is deleted
+6. CI must be green before merge
 
 ---
 
-## Связь с GitHub Issues
+## Link with GitHub Issues
 
-**Воркфлоу:**
-1. Создать Issue на GitHub → получить номер (`#42`)
-2. Создать ветку с этим номером
-3. В описании PR написать `closes #42`
-4. После merge в `develop` — Issue закроется автоматически
+> How to format the issue itself (title, labels, body) — see the "Issues" section above.
+
+**Workflow:**
+1. Create an Issue on GitHub → get the number (`#42`)
+2. Create a branch with that number
+3. Write `Closes #42` in the PR description
+4. After merge into `develop` — the issue closes automatically
 
 ```
 feat/42/dark-theme-support
@@ -134,4 +230,5 @@ feat/42/dark-theme-support
    issue #42
 ```
 
-Типы задач для Issues: `bug`, `enhancement`, `refactor`, `chore`, `docs` — используй GitHub Labels.
+The task type is visible from the title prefix (`feat`/`fix`/`refactor`/...); labels are used
+only for priority — see the "Issues" section above.


### PR DESCRIPTION
## What
- Translate `CONTRIBUTING.md` from Russian to English (matches the English README).
- Refine conventions:
  - Commit: subject ≤50 chars, body only for non-trivial changes.
  - PR title stays a clean Conventional Commit — no issue-number prefix; link the issue via `Closes #<id>` in the body.
  - English PR description template (What / Why / How to test).
  - Add a `Reproduction` section (Steps / Expected / Actual / Environment) to the bug-issue template.

## Why
- Align the contributor guide language with the English README for external readers.
- Keep PR titles tooling-safe for squash-merge / semantic-release / title linters.
- Make bug issues actionable with explicit reproduction steps.

## How to test
- Docs only — render the markdown and confirm the sections read correctly.
