### PR TITLE
fix(home): show total due count on deck badge

### DIFF
--- a/feature/home/src/commonMain/kotlin/com/mindeck/feature/home/components/DeckList.kt
+++ b/feature/home/src/commonMain/kotlin/com/mindeck/feature/home/components/DeckList.kt
@@ -163,7 +163,7 @@ private fun DeckListItem(
                     contentAlignment = Alignment.Center,
                 ) {
                     Text(
-                        text = deck.reviewCount.toString(),
+                        text = deck.dueCount.toString(),
                         style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.Bold),
                         color = MaterialTheme.colorScheme.onPrimaryContainer,
                     )

--- a/feature/home/src/commonMain/kotlin/com/mindeck/feature/home/model/DeckItem.kt
+++ b/feature/home/src/commonMain/kotlin/com/mindeck/feature/home/model/DeckItem.kt
@@ -11,5 +11,7 @@ data class DeckItem(
     val newReviewCount: Int,
     val reviewCount: Int,
 ) {
-    val hasCardsToReview: Boolean get() = newCount + newReviewCount + reviewCount > 0
+    val dueCount: Int get() = newCount + newReviewCount + reviewCount
+
+    val hasCardsToReview: Boolean get() = dueCount > 0
 }


### PR DESCRIPTION
## What
- Render the deck badge as the total due count (`newCount + newReviewCount + reviewCount`) instead of `reviewCount` alone.
- Introduce `DeckItem.dueCount` and reuse it in `hasCardsToReview` to remove the duplicated three-field sum.

## Why
- A deck whose due cards are all "new" (`reviewCount == 0`) was flagged as having cards to review yet showed a "0" badge, contradicting the hero card's due count right above it.

## How to test
- On a physical device (Android 15), a deck with 5 new cards now shows a "5" badge (was "0"), matching the hero card's "5 new".

Closes #114
