### PR TITLE
fix: uppercase the deck cover initial

### DIFF
--- a/core/ui/src/commonMain/kotlin/com/mindeck/core/ui/format/DeckCover.kt
+++ b/core/ui/src/commonMain/kotlin/com/mindeck/core/ui/format/DeckCover.kt
@@ -1,0 +1,3 @@
+package com.mindeck.core.ui.format
+
+fun deckCoverInitial(title: String): String = title.firstOrNull()?.uppercaseChar()?.toString() ?: ""

--- a/feature/card/src/commonMain/kotlin/com/mindeck/feature/card/components/DeckSection.kt
+++ b/feature/card/src/commonMain/kotlin/com/mindeck/feature/card/components/DeckSection.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.text.font.FontWeight
+import com.mindeck.core.ui.format.deckCoverInitial
 import com.mindeck.core.ui.spacer.HorizontalSpacer
 import com.mindeck.core.ui.spacer.VerticalSpacer
 import com.mindeck.core.ui.theme.MindeckTheme
@@ -236,7 +237,7 @@ private fun SelectedDeck(
                 contentAlignment = Alignment.Center,
             ) {
                 Text(
-                    text = deck.title.firstOrNull()?.toString() ?: "",
+                    text = deckCoverInitial(deck.title),
                     style = MaterialTheme.typography.titleMedium,
                     color = swatch.onContainer,
                 )
@@ -523,7 +524,7 @@ private fun DeckListItem(
                     contentAlignment = Alignment.Center,
                 ) {
                     Text(
-                        text = deck.title.firstOrNull()?.toString() ?: "",
+                        text = deckCoverInitial(deck.title),
                         style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
                         color = swatch.onContainer,
                     )

--- a/feature/home/src/commonMain/kotlin/com/mindeck/feature/home/components/DeckList.kt
+++ b/feature/home/src/commonMain/kotlin/com/mindeck/feature/home/components/DeckList.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
+import com.mindeck.core.ui.format.deckCoverInitial
 import com.mindeck.core.ui.theme.MindeckTheme
 import com.mindeck.feature.home.model.DeckItem
 import mindeck_app.core.ui.generated.resources.Res
@@ -124,7 +125,7 @@ private fun DeckListItem(
                     contentAlignment = Alignment.Center,
                 ) {
                     Text(
-                        text = deck.title.firstOrNull()?.toString() ?: "",
+                        text = deckCoverInitial(deck.title),
                         style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
                         color = swatch.onContainer,
                     )


### PR DESCRIPTION
## What
- Extract the deck-cover first-letter logic into a shared `deckCoverInitial` helper in `core:ui` that uppercases the initial.
- Use it in the three previously-duplicated call sites (Home deck list, and the create-card deck picker: selected deck + list item).

## Why
- Deck covers showed a lowercase initial (e.g. "п" instead of "П"), inconsistent with the create-deck dialog preview, which already uppercases.
- The first-letter snippet was duplicated three times across two modules — one helper removes the duplication and guarantees consistent casing.

## How to test
- On a physical device (Android 15): the deck "п" now shows a "П" cover on Home, in the deck-picker list, and as the selected deck. The deck name itself stays "п".

Closes #117
