### PR TITLE
fix(card): preserve unsaved CreateCard draft across recreation

### DIFF
--- a/app/src/commonMain/kotlin/com/mindeck/app/navigation/RootComponent.kt
+++ b/app/src/commonMain/kotlin/com/mindeck/app/navigation/RootComponent.kt
@@ -7,7 +7,7 @@ import com.arkivanov.decompose.router.stack.childStack
 import com.arkivanov.decompose.router.stack.pop
 import com.arkivanov.decompose.router.stack.pushNew
 import com.arkivanov.decompose.value.Value
-import com.arkivanov.essenty.lifecycle.doOnDestroy
+import com.arkivanov.essenty.instancekeeper.getOrCreate
 import com.mindeck.feature.card.createCard.CreateCardViewModel
 import com.mindeck.feature.home.HomeViewModel
 import org.koin.core.component.KoinComponent
@@ -38,13 +38,11 @@ class RootComponent(
     ): Child =
         when (config) {
             is Config.Home -> {
-                val viewModel = get<HomeViewModel>()
-                context.lifecycle.doOnDestroy(viewModel::clear)
+                val viewModel = context.instanceKeeper.getOrCreate { get<HomeViewModel>() }
                 Child.Home(viewModel)
             }
             is Config.CreateCard -> {
-                val viewModel = get<CreateCardViewModel>()
-                context.lifecycle.doOnDestroy(viewModel::clear)
+                val viewModel = context.instanceKeeper.getOrCreate { get<CreateCardViewModel>() }
                 Child.CreateCard(viewModel)
             }
         }

--- a/app/src/commonMain/kotlin/com/mindeck/app/navigation/RootComponent.kt
+++ b/app/src/commonMain/kotlin/com/mindeck/app/navigation/RootComponent.kt
@@ -8,10 +8,15 @@ import com.arkivanov.decompose.router.stack.pop
 import com.arkivanov.decompose.router.stack.pushNew
 import com.arkivanov.decompose.value.Value
 import com.arkivanov.essenty.instancekeeper.getOrCreate
+import com.mindeck.feature.card.createCard.CreateCardDraft
+import com.mindeck.feature.card.createCard.CreateCardState
 import com.mindeck.feature.card.createCard.CreateCardViewModel
+import com.mindeck.feature.card.createCard.toDraft
+import com.mindeck.feature.card.createCard.toState
 import com.mindeck.feature.home.HomeViewModel
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
+import org.koin.core.parameter.parametersOf
 
 class RootComponent(
     componentContext: ComponentContext,
@@ -42,8 +47,22 @@ class RootComponent(
                 Child.Home(viewModel)
             }
             is Config.CreateCard -> {
-                val viewModel = context.instanceKeeper.getOrCreate { get<CreateCardViewModel>() }
+                val viewModel =
+                    context.instanceKeeper.getOrCreate {
+                        val restored =
+                            context.stateKeeper
+                                .consume(CREATE_CARD_DRAFT_KEY, CreateCardDraft.serializer())
+                                ?.toState()
+                        get<CreateCardViewModel> { parametersOf(restored ?: CreateCardState()) }
+                    }
+                context.stateKeeper.register(CREATE_CARD_DRAFT_KEY, CreateCardDraft.serializer()) {
+                    viewModel.state.value.toDraft()
+                }
                 Child.CreateCard(viewModel)
             }
         }
+
+    private companion object {
+        const val CREATE_CARD_DRAFT_KEY = "create_card_draft"
+    }
 }

--- a/core/mvi/build.gradle.kts
+++ b/core/mvi/build.gradle.kts
@@ -23,6 +23,9 @@ kotlin {
             dependencies {
                 // Coroutines
                 api(libs.coroutines)
+
+                // Navigation
+                api(libs.decompose.decompose)
             }
         }
     }

--- a/core/mvi/src/commonMain/kotlin/com/mindeck/core/mvi/BaseViewModel.kt
+++ b/core/mvi/src/commonMain/kotlin/com/mindeck/core/mvi/BaseViewModel.kt
@@ -1,5 +1,6 @@
 package com.mindeck.core.mvi
 
+import com.arkivanov.essenty.instancekeeper.InstanceKeeper
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -15,7 +16,7 @@ import kotlinx.coroutines.flow.update
 
 abstract class BaseViewModel<State, Intent, Effect>(
     initialState: State,
-) : Store<State, Intent, Effect> {
+) : Store<State, Intent, Effect>, InstanceKeeper.Instance {
     val handler =
         CoroutineExceptionHandler { _, exception ->
             println("[BaseViewModel] Unhandled exception in viewModelScope: ${exception.stackTraceToString()}")
@@ -39,7 +40,7 @@ abstract class BaseViewModel<State, Intent, Effect>(
         _effects.trySend(effect)
     }
 
-    open fun clear() {
+    override fun onDestroy() {
         viewModelScope.cancel()
     }
 }

--- a/core/mvi/src/commonMain/kotlin/com/mindeck/core/mvi/BaseViewModel.kt
+++ b/core/mvi/src/commonMain/kotlin/com/mindeck/core/mvi/BaseViewModel.kt
@@ -16,7 +16,8 @@ import kotlinx.coroutines.flow.update
 
 abstract class BaseViewModel<State, Intent, Effect>(
     initialState: State,
-) : Store<State, Intent, Effect>, InstanceKeeper.Instance {
+) : Store<State, Intent, Effect>,
+    InstanceKeeper.Instance {
     val handler =
         CoroutineExceptionHandler { _, exception ->
             println("[BaseViewModel] Unhandled exception in viewModelScope: ${exception.stackTraceToString()}")

--- a/feature/card/build.gradle.kts
+++ b/feature/card/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.android.kotlin.multiplatform.library)
     alias(libs.plugins.compose.multiplatform)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.jetbrains.kotlin.serialization)
 }
 
 compose.resources {
@@ -67,6 +68,9 @@ kotlin {
 
                 // KotlinX
                 implementation(libs.kotlinx.datetime)
+
+                // Serialization
+                implementation(libs.kotlinx.serialization.core)
 
                 // Media
                 implementation(libs.filekit.dialogs)

--- a/feature/card/src/commonMain/kotlin/com/mindeck/feature/card/createCard/CreateCardDraft.kt
+++ b/feature/card/src/commonMain/kotlin/com/mindeck/feature/card/createCard/CreateCardDraft.kt
@@ -1,0 +1,32 @@
+package com.mindeck.feature.card.createCard
+
+import com.mindeck.feature.card.model.CardType
+import com.mindeck.feature.card.model.TextFormat
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CreateCardDraft(
+    val question: String = "",
+    val answer: String = "",
+    val hint: String? = null,
+    val selectedType: CardType = CardType.SIMPLE,
+    val activeFormats: Set<TextFormat> = emptySet(),
+)
+
+fun CreateCardState.toDraft(): CreateCardDraft =
+    CreateCardDraft(
+        question = question,
+        answer = answer,
+        hint = hint,
+        selectedType = selectedType,
+        activeFormats = activeFormats,
+    )
+
+fun CreateCardDraft.toState(): CreateCardState =
+    CreateCardState(
+        question = question,
+        answer = answer,
+        hint = hint,
+        selectedType = selectedType,
+        activeFormats = activeFormats,
+    )

--- a/feature/card/src/commonMain/kotlin/com/mindeck/feature/card/di/CardModule.kt
+++ b/feature/card/src/commonMain/kotlin/com/mindeck/feature/card/di/CardModule.kt
@@ -1,9 +1,19 @@
 package com.mindeck.feature.card.di
 
+import com.mindeck.feature.card.createCard.CreateCardState
 import com.mindeck.feature.card.createCard.CreateCardViewModel
 import org.koin.dsl.module
 
 val cardModule =
     module {
-        factory { CreateCardViewModel(get(), get(), get(), get(), get()) }
+        factory { params ->
+            CreateCardViewModel(
+                get(),
+                get(),
+                get(),
+                get(),
+                get(),
+                initialState = params.getOrNull<CreateCardState>() ?: CreateCardState(),
+            )
+        }
     }

--- a/feature/card/src/commonMain/kotlin/com/mindeck/feature/card/model/CardType.kt
+++ b/feature/card/src/commonMain/kotlin/com/mindeck/feature/card/model/CardType.kt
@@ -1,5 +1,8 @@
 package com.mindeck.feature.card.model
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 enum class CardType {
     SIMPLE,
     COMPLEX,

--- a/feature/card/src/commonMain/kotlin/com/mindeck/feature/card/model/TextFormat.kt
+++ b/feature/card/src/commonMain/kotlin/com/mindeck/feature/card/model/TextFormat.kt
@@ -1,5 +1,8 @@
 package com.mindeck.feature.card.model
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 enum class TextFormat {
     BOLD,
     ITALIC,


### PR DESCRIPTION
## What

Preserve the in-progress "New card" draft when the screen is recreated.

- **Config change** (font size, split-screen, etc.): ViewModels are now held in the child `InstanceKeeper` via `getOrCreate`, so the live instance — including an attached image — survives Activity recreation.
- **Process death** (OS reclaims the backgrounded app): a serializable draft (question, answer, hint, type, formats) is saved via `StateKeeper` and restored on relaunch. Image bytes are intentionally excluded — they don't fit the ~1 MB saved-state Bundle, so the image is dropped on process death.

The ViewModel stays platform-agnostic: all `StateKeeper`/`InstanceKeeper` wiring lives in `RootComponent`, and the restored draft is passed through the existing `initialState` constructor parameter.

## Why

Previously the draft was lost on rotation-class config changes and on process death — `RootComponent` recreated a fresh empty ViewModel via Koin (`get<CreateCardViewModel>()`). A user who backgrounded the app mid-card lost everything.

## How to test

1. Enable Developer Options → **Don't keep activities**.
2. Open **New card**, type a question and answer, switch type to **Complex**.
3. Press **Home**, then return to the app.
4. Expected: the screen reopens on **New card** with the text and type restored.
5. Press **Back** to leave the screen, then reopen it → the form is empty (no stale draft).

Verified live on a physical device (Android 15).

Closes #112
