### PR TITLE
fix: render apostrophe correctly in home empty-state copy

### DIFF
--- a/feature/card/src/commonMain/kotlin/com/mindeck/feature/card/components/ImagePickers.kt
+++ b/feature/card/src/commonMain/kotlin/com/mindeck/feature/card/components/ImagePickers.kt
@@ -81,5 +81,4 @@ private suspend fun readPickedImage(file: PlatformFile): DraftImage? {
     }
 }
 
-internal fun cameraCaptureImage(bytes: ByteArray) =
-    draftImageFromBytes(url = "camera:${Random.nextLong()}", bytes = bytes)
+internal fun cameraCaptureImage(bytes: ByteArray) = draftImageFromBytes(url = "camera:${Random.nextLong()}", bytes = bytes)

--- a/feature/card/src/commonMain/kotlin/com/mindeck/feature/card/createCard/CreateCardViewModel.kt
+++ b/feature/card/src/commonMain/kotlin/com/mindeck/feature/card/createCard/CreateCardViewModel.kt
@@ -87,11 +87,13 @@ class CreateCardViewModel(
             CreateCardIntent.DismissCamera -> updateState { it.copy(isCameraVisible = false, cameraSessionId = it.cameraSessionId + 1) }
             is CreateCardIntent.CameraCaptured ->
                 if (intent.sessionId == currentState.cameraSessionId) {
-                    updateState { it.copy(
-                        draftImage = intent.image,
-                        isProcessingImage = false,
-                        isCameraVisible = false
-                    ) }
+                    updateState {
+                        it.copy(
+                            draftImage = intent.image,
+                            isProcessingImage = false,
+                            isCameraVisible = false,
+                        )
+                    }
                 } else {
                     Unit
                 }

--- a/feature/home/src/commonMain/composeResources/values/strings.xml
+++ b/feature/home/src/commonMain/composeResources/values/strings.xml
@@ -7,7 +7,7 @@
     <string name="home_error_retry">Retry loading</string>
 
     <string name="home_empty_title">Nothing here yet</string>
-    <string name="home_empty_subtitle">Create your first card — a deck will be created for it automatically. Mindeck will remind you when it\'s time to review.</string>
+    <string name="home_empty_subtitle">Create your first card — a deck will be created for it automatically. Mindeck will remind you when it's time to review.</string>
     <string name="home_empty_create_card">Create card</string>
     <string name="home_empty_import_deck">Import deck</string>
     <string name="home_empty_hint">A card is a question and an answer. You can set the deck name right when creating it.</string>


### PR DESCRIPTION
## What

The home empty-state subtitle used the Android XML apostrophe escape (`\'`), which Compose Multiplatform's `composeResources` parser renders literally — the UI showed the apostrophe with a visible backslash on screen.

## Fix

Use a plain apostrophe in `home_empty_subtitle`. CMP resources do not use Android's XML apostrophe-escaping convention.

## Verification

Confirmed on the iOS simulator: the empty state now reads "…when it's time to review."