### PR TITLE
ci: add GitHub Actions workflow for Android and iOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  android:
+    name: Android — build & test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate Gradle wrapper
+        uses: gradle/actions/wrapper-validation@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Check formatting (Spotless)
+        run: ./gradlew spotlessCheck --stacktrace
+
+      - name: Build debug APK
+        run: ./gradlew assembleDebug --stacktrace
+
+      - name: Unit tests
+        run: ./gradlew testDebugUnitTest testAndroidHostTest jvmTest --stacktrace
+
+  ios:
+    name: iOS — compile shared framework
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Link iOS framework (simulator)
+        run: ./gradlew :app:linkDebugFrameworkIosSimulatorArm64 --stacktrace

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Mindeck
 
+[![CI](https://github.com/DenisFrolkov/mindeck-app/actions/workflows/ci.yml/badge.svg)](https://github.com/DenisFrolkov/mindeck-app/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Min SDK](https://img.shields.io/badge/Min%20SDK-26-green.svg)](https://developer.android.com/about/versions/oreo)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.3.21-purple.svg)](https://kotlinlang.org)

--- a/androidApp/build.gradle.kts
+++ b/androidApp/build.gradle.kts
@@ -27,11 +27,13 @@ android {
     }
 
     signingConfigs {
-        create("release") {
-            storeFile = file(localProperties["signing.storeFile"] as String)
-            storePassword = localProperties["signing.storePassword"] as String
-            keyAlias = localProperties["signing.keyAlias"] as String
-            keyPassword = localProperties["signing.keyPassword"] as String
+        if (localProperties["signing.storeFile"] != null) {
+            create("release") {
+                storeFile = file(localProperties["signing.storeFile"] as String)
+                storePassword = localProperties["signing.storePassword"] as String
+                keyAlias = localProperties["signing.keyAlias"] as String
+                keyPassword = localProperties["signing.keyPassword"] as String
+            }
         }
     }
 
@@ -41,7 +43,7 @@ android {
             versionNameSuffix = "-debug"
         }
         release {
-            signingConfig = signingConfigs.getByName("release")
+            signingConfig = signingConfigs.findByName("release")
             isMinifyEnabled = true
             isShrinkResources = true
             proguardFiles(


### PR DESCRIPTION
## What

Add a fresh GitHub Actions CI workflow (`.github/workflows/ci.yml`) that verifies every push and pull request against `develop`. No CD — build/test/lint only.

### Jobs

- **Android** (`ubuntu-latest`) — validates the Gradle wrapper, then runs:
  - `spotlessCheck` — Kotlin/ktlint formatting gate
  - `assembleDebug` — builds the Android debug APK
  - `testDebugUnitTest testAndroidHostTest jvmTest` — unit tests across `androidApp`, `data`, and `domain`
- **iOS** (`macos-latest`) — compiles and links the shared Kotlin/Native framework (`:app:linkDebugFrameworkIosSimulatorArm64`), proving the iOS side of the Kotlin Multiplatform build stays green.

### Details

- Triggers: `push` and `pull_request` targeting `develop`.
- `concurrency` cancels superseded runs on the same ref.
- Gradle caching via `gradle/actions/setup-gradle`.
- JDK 17 (Temurin), matching the project's `javaVersion`.

Also adds a CI status badge to the README.

## Verification

The full task set was run locally on `develop` and is green (`spotlessCheck`, `assembleDebug`, all unit tests, and the iOS framework link).


## Build fix (required for CI)

`androidApp` unconditionally read the release signing config from `local.properties` and cast the values to non-null `String`. On a clean checkout (CI has no `local.properties`) that threw `NullPointerException` during Gradle configuration, before any task ran. The release signing config is now created only when the signing properties are present; CI configures cleanly and builds the debug variant.